### PR TITLE
guard against incomplete Property data with default values

### DIFF
--- a/src/buildings/buildings.service.ts
+++ b/src/buildings/buildings.service.ts
@@ -2060,8 +2060,8 @@ export class BuildingsService {
         postalCode: building.Property[0].postCode,
         suburb: null,
         location: {
-          lat: parseFloat(building.Property[0].latitude.toString()),
-          lng: parseFloat(building.Property[0].longitude.toString()),
+          lat: building.Property[0].latitude ? parseFloat(building.Property[0].latitude.toString()) : 0.0,
+          lng: building.Property[0].longitude ? parseFloat(building.Property[0].longitude.toString()) : 0.0,
         },
         storeysAboveGround: building.storeysAboveGround,
         storeysBelowGround: building.storeysBelowGround,


### PR DESCRIPTION
I know this is not the best solution. I wrote this in 10 minutes to hopefully get rid of the following error message that we saw when we try to write a demo presentation for clients.

```
[Nest] 31  - 06/11/2024, 9:17:08 AM   ERROR [ExceptionsHandler] Cannot read properties of null (reading 'toString')
TypeError: Cannot read properties of null (reading 'toString')
    at BuildingsService.findOneForEditing (/usr/src/app/src/buildings/buildings.service.ts:2069:57)
    at /usr/src/app/node_modules/@nestjs/core/router/router-execution-context.js:46:28
    at /usr/src/app/node_modules/@nestjs/core/router/router-proxy.js:9:17
```